### PR TITLE
Fix watcher setup for non-default api endpoints

### DIFF
--- a/src/main/java/org/testobject/appium/junit/TestObjectTestResultWatcher.java
+++ b/src/main/java/org/testobject/appium/junit/TestObjectTestResultWatcher.java
@@ -47,6 +47,7 @@ public class TestObjectTestResultWatcher extends TestWatcher {
 
 	public void setRemoteWebDriver(RemoteWebDriver driver, URL apiEndpoint) {
 		provider.setDriver(driver, apiEndpoint);
+		reporter = new IntermediateReporter(provider);
 	}
 
 	public void setIsLocalTest(boolean isLocalTest) {


### PR DESCRIPTION
When running the intermediate setup on API endpoints other than
production, we were failing to set the reporter. This broke result
reporting for the intermediate setup on all API endpoints other than
production (staging, locally). When the result was to be reported, there
would be a null pointer exception.